### PR TITLE
Add missing std:: in front of isnan()

### DIFF
--- a/src/unit/dakota_tolerance_intervals/test_tolerance_intervals.cpp
+++ b/src/unit/dakota_tolerance_intervals/test_tolerance_intervals.cpp
@@ -517,8 +517,8 @@ void test_DSTIEN_valid_input_04_noValidResponseSamples()
   // ************************************************************************
   BOOST_CHECK( num_valid_samples == 0 );
   for (size_t k = 0; k < num_fns; ++k) {
-    BOOST_CHECK( isnan(computed_dstien_mus   [k]) );
-    BOOST_CHECK( isnan(computed_dstien_sigmas[k]) );
+    BOOST_CHECK( std::isnan(computed_dstien_mus   [k]) );
+    BOOST_CHECK( std::isnan(computed_dstien_sigmas[k]) );
   }
 }
 
@@ -587,7 +587,7 @@ void test_DSTIEN_valid_input_05_justOneValidResponseSample()
   BOOST_CHECK( num_valid_samples == 1 );
   for (size_t k = 0; k < num_fns; ++k) {
     BOOST_CHECK( computed_dstien_mus[k] == expected_dstien_mus[k] );
-    BOOST_CHECK( isnan(computed_dstien_sigmas[k]) );
+    BOOST_CHECK( std::isnan(computed_dstien_sigmas[k]) );
   }
 }
 


### PR DESCRIPTION
Dakota does not compile with gcc-12 -std=c++14 / Boost 1.82.0 due to missing std:: namespace in front of isnan() in test_tolerance_intervals.cpp