### PR TITLE
Make sure the adaptive sampling algorithm works in batch mode

### DIFF
--- a/src/NonDAdaptiveSampling.cpp
+++ b/src/NonDAdaptiveSampling.cpp
@@ -298,14 +298,30 @@ namespace Dakota
 			// add new_X to the build points and append approximation
 			VariablesArray points_to_add;
 			IntResponseMap responses_to_add;
-			for(int i = 0; i < new_Xs.size(); i++) 
-			{
-				iteratedModel.continuous_variables(new_Xs[i]);
-				iteratedModel.evaluate();
-				responses_to_add.insert(IntResponsePair(iteratedModel.evaluation_id(),
-										iteratedModel.current_response()));
-				points_to_add.push_back(iteratedModel.current_variables());
-			}
+            if (iteratedModel.asynch_flag())
+            {
+                fout << "\nUsing async evaluation" << std::endl;
+            
+                for(int i = 0; i < new_Xs.size(); i++) 
+                {
+                    iteratedModel.continuous_variables(new_Xs[i]);
+                    iteratedModel.evaluate_nowait();
+                    points_to_add.push_back(iteratedModel.current_variables());
+                }
+
+                // Wait for the responses.
+                responses_to_add = iteratedModel.synchronize(); 
+            }
+            else {
+                for(int i = 0; i < new_Xs.size(); i++) 
+                {
+                    iteratedModel.continuous_variables(new_Xs[i]);
+                    iteratedModel.evaluate();
+                    responses_to_add.insert(IntResponsePair(iteratedModel.evaluation_id(),
+                                            iteratedModel.current_response()));
+                    points_to_add.push_back(iteratedModel.current_variables());
+                }
+            }
 
 			gpModel.append_approximation(points_to_add,responses_to_add, true);
 			


### PR DESCRIPTION
We noticed that when the adaptive sampling method (which is marked as experimental), is used together with batch mode, it doesn't work. The initial sampling points are done in batches, but then the sampling switches to single evaluations, and the evaluation function suddenly doesn't receive batches anymore.

I've made the code changes described in this PR. It looks like it's working, because now batch mode gives exactly the same results as non-batch mode. 

I'm only a bit uncertain about line 309 (new code) though. Could somebody comment on if it makes sense to push the variables in the for loop? I'm a bit worried they might end up with the wrong responses, since we're in asynchronous mode here.